### PR TITLE
reset db and add conditional seeding

### DIFF
--- a/.env
+++ b/.env
@@ -5,4 +5,5 @@ POSTGRES_PASSWORD=postgres
 POSTGRES_DB=solutions_db
 POSTGRESQL_DB_CONNECT_STRING=postgresql://postgres:postgres@db:5432/solutions_db
 HMAC_SECRET_KEY=secret-key
+SKIP_SEED=false
 # FLASK_OPENID_LAUNCHPAD_TEAM=

--- a/migrations/versions/a911d519ae4b_initial_migration_with_current_models.py
+++ b/migrations/versions/a911d519ae4b_initial_migration_with_current_models.py
@@ -1,8 +1,8 @@
-"""initial migration
+"""initial migration with current models
 
-Revision ID: 79b5d402cbe4
+Revision ID: a911d519ae4b
 Revises: 
-Create Date: 2025-07-18 07:36:47.257188
+Create Date: 2025-08-12 05:38:51.355734
 
 """
 from alembic import op
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision = '79b5d402cbe4'
+revision = 'a911d519ae4b'
 down_revision = None
 branch_labels = None
 depends_on = None
@@ -33,6 +33,7 @@ def upgrade():
     )
     op.create_table('solution',
     sa.Column('id', sa.Integer(), nullable=False),
+    sa.Column('hash', sa.String(length=16), nullable=False),
     sa.Column('name', sa.String(), nullable=False),
     sa.Column('revision', sa.Integer(), nullable=False),
     sa.Column('created_by', sa.String(), nullable=False),
@@ -43,7 +44,7 @@ def upgrade():
     sa.Column('icon', sa.String(), nullable=True),
     sa.Column('created', sa.DateTime(), nullable=False),
     sa.Column('last_updated', sa.DateTime(), nullable=False),
-    sa.Column('status', sa.Enum('PENDING', 'UNPUBLISHED', 'PENDING_REVIEW', 'PUBLISHED', name='solutionstatus'), nullable=False),
+    sa.Column('status', sa.Enum('PENDING_NAME_REVIEW', 'DRAFT', 'PENDING_METADATA_REVIEW', 'PUBLISHED', 'UNPUBLISHED', name='solutionstatus'), nullable=False),
     sa.Column('platform', sa.Enum('KUBERNETES', 'MACHINE', name='platformtypes'), nullable=False),
     sa.Column('platform_version', sa.JSON(), nullable=True),
     sa.Column('platform_prerequisites', sa.JSON(), nullable=True),
@@ -60,6 +61,7 @@ def upgrade():
     sa.Column('visibility', sa.Enum('PUBLIC', 'PRIVATE', name='visibility'), nullable=False),
     sa.ForeignKeyConstraint(['publisher_id'], ['publisher.publisher_id'], ),
     sa.PrimaryKeyConstraint('id'),
+    sa.UniqueConstraint('hash'),
     sa.UniqueConstraint('name', 'revision', name='_solution_revision_uc')
     )
     op.create_table('charm',
@@ -74,7 +76,7 @@ def upgrade():
     sa.Column('id', sa.Integer(), nullable=False),
     sa.Column('solution_id', sa.Integer(), nullable=False),
     sa.Column('reviewer_id', sa.String(), nullable=False),
-    sa.Column('action', sa.Enum('APPROVE_REGISTRATION', 'PUBLISH', 'UNPUBLISH', name='revieweractiontype'), nullable=False),
+    sa.Column('action', sa.Enum('APPROVE_REGISTRATION', 'PUBLISH', name='revieweractiontype'), nullable=False),
     sa.Column('comment', sa.Text(), nullable=True),
     sa.Column('timestamp', sa.DateTime(), nullable=False),
     sa.ForeignKeyConstraint(['solution_id'], ['solution.id'], ),

--- a/seed.py
+++ b/seed.py
@@ -13,14 +13,23 @@ from app.models import (
 from datetime import datetime
 from app import create_app
 import uuid
+import os
 
 app = create_app()
 
 
 def seed_database():
-    with app.app_context():
-        db.drop_all()
-        db.create_all()
+    with app.app_context():        
+        # Check if seeding should run
+        skip_seed = os.getenv('SKIP_SEED', 'false').lower() == 'true'
+        if skip_seed:
+            print("SKIP_SEED=true, skipping database seeding...")
+            return
+            
+        # Check if database already has data
+        if Solution.query.first() is not None:
+            print("Database already seeded, skipping...")
+            return
 
         mock_data = [
             {


### PR DESCRIPTION
## Done
Context: the seed file was doing `drop_all` and `create_all` every time it was running, so there was a mismatch between the db migrations and the updated models. This PR:
- Resets DB initial migration to match database models to reflect what the models now look like
- Amends the logic so that the seed file no longer drops and creates tables when running
  - Adds conditional checks to see if data already exists or if seeding is turned off in the `.env` file
- Going forward, any changes made to the DB models should be updated with a new DB migration

## QA
Check out this branch
1. Run `docker compose up --build`
    - Make sure you see "Database seeded successfully" printed and that there is data in `localhost:5000`
2. `cmd + c` in the terminal but don't do `docker compose down -v`
    - Run `docker compose up --build` again and make sure "Database already seeded, skipping..." is printed
3. `cmd + c` and `docker compose down -v` in the terminal
    - Change the `SKIP_SEED` env variable in `.env` to `true` 
    - Run `docker compose up --build` and make sure "SKIP_SEED=true, skipping database seeding..." is printed

## Issue
Fixes [WD-24675](https://warthogs.atlassian.net/browse/WD-24675)

[WD-24675]: https://warthogs.atlassian.net/browse/WD-24675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ