### PR TITLE
Chore/health check updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ COPY entrypoint.sh .
 
 
 ENTRYPOINT ["/app/entrypoint.sh"]
-CMD ["0.0.0.0", "80"]
+CMD ["flask", "run", "--host=0.0.0.0", "--port=80"]

--- a/app/public/launchpad.py
+++ b/app/public/launchpad.py
@@ -1,8 +1,9 @@
 import requests
 import functools
-import time 
+import time
 
 LAUNCHPAD_URL = "https://api.launchpad.net/1.0/"
+LAUNCHPAD_TIMEOUT = 10
 
 def time_cache(max_age, maxsize=128):
     """Least-recently-used cache decorator with time-based cache invalidation.
@@ -29,7 +30,7 @@ def time_cache(max_age, maxsize=128):
 @time_cache(max_age=3600)
 def get_user_teams(username):
     url = f"{LAUNCHPAD_URL}/~{username}/super_teams"
-    response = requests.get(url)
+    response = requests.get(url, timeout=LAUNCHPAD_TIMEOUT)
 
     if response.status_code != 200:
         raise Exception(
@@ -44,7 +45,7 @@ def get_launchpad_team(team_name):
     url = f"{LAUNCHPAD_URL}/~{team_name}"
 
     try:
-        response = requests.get(url, timeout=10)
+        response = requests.get(url, timeout=LAUNCHPAD_TIMEOUT)
 
         if response.status_code == 404:
             return None

--- a/app/public/logic.py
+++ b/app/public/logic.py
@@ -1,6 +1,6 @@
 from app.extensions import db
 from app.models import Solution, SolutionStatus, Visibility
-from app.utils import serialize_solution
+from app.utils import serialize_public_solution
 
 
 def _published_public_filter():
@@ -14,7 +14,7 @@ def get_all_published_solutions():
     solutions = (
         db.session.query(Solution).filter(*_published_public_filter()).all()
     )
-    return [serialize_solution(solution) for solution in solutions]
+    return [serialize_public_solution(solution) for solution in solutions]
 
 
 def get_published_solution_by_name(name: str):
@@ -27,7 +27,7 @@ def get_published_solution_by_name(name: str):
         .order_by(Solution.revision.desc())
         .first()
     )
-    return serialize_solution(solution) if solution else None
+    return serialize_public_solution(solution) if solution else None
 
 
 def search_published_solutions(query: str):
@@ -46,7 +46,7 @@ def search_published_solutions(query: str):
         )
         .all()
     )
-    return [serialize_solution(solution) for solution in results]
+    return [serialize_public_solution(solution) for solution in results]
 
 
 def get_published_solution_by_hash(hash: str):
@@ -66,14 +66,14 @@ def get_published_solution_by_hash(hash: str):
         solution.status == SolutionStatus.PUBLISHED
         and solution.visibility == Visibility.PUBLIC
     ):
-        return serialize_solution(solution)
+        return serialize_public_solution(solution)
 
     # allow previewing pending solutions (for review dashboard)
     if solution.status in [
         SolutionStatus.PENDING_NAME_REVIEW,
         SolutionStatus.PENDING_METADATA_REVIEW,
     ]:
-        return serialize_solution(solution)
+        return serialize_public_solution(solution)
 
     # if solution is unpublished, try to find the latest published revision
     if solution.status == SolutionStatus.UNPUBLISHED:
@@ -87,7 +87,7 @@ def get_published_solution_by_hash(hash: str):
             .first()
         )
         if latest_published:
-            return serialize_solution(latest_published)
+            return serialize_public_solution(latest_published)
 
     # solution exists but is not published/public and no published version found
     return None

--- a/app/publisher/api.py
+++ b/app/publisher/api.py
@@ -150,7 +150,10 @@ def update_solution_revision(name, rev):
     if not data:
         return jsonify({"error": "No data provided"}), 400
 
-    updated_solution = update_solution_metadata(name, rev, data)
+    try:
+        updated_solution = update_solution_metadata(name, rev, data)
+    except ValidationError as e:
+        return jsonify({"error-list": e.errors}), 400
 
     if not updated_solution:
         return jsonify({"error": "Failed to update solution"}), 500

--- a/app/publisher/logic.py
+++ b/app/publisher/logic.py
@@ -41,6 +41,11 @@ EDITABLE_FIELDS = {
     "juju_versions",
 }
 
+SOLUTION_NAME_MAX_LENGTH = 40
+SOLUTION_TITLE_MAX_LENGTH = 40
+SOLUTION_SUMMARY_MAX_LENGTH = 500
+SUPPORTED_PLATFORMS = {platform.value for platform in PlatformTypes}
+
 
 def find_or_create_creator(
     creator_email: str,
@@ -87,7 +92,7 @@ def find_or_create_maintainer(email: str):
 
 
 def validate_solution_name(name: str) -> bool:
-    if not name:
+    if not name or len(name) > SOLUTION_NAME_MAX_LENGTH:
         return False
 
     if not re.match(r"^[a-z0-9]+(?:-[a-z0-9]+)*$", name):
@@ -100,13 +105,21 @@ def validate_solution_name(name: str) -> bool:
 
 
 def validate_solution_title(title: str) -> bool:
-    if not title:
+    if not title or len(title) > SOLUTION_TITLE_MAX_LENGTH:
         return False
 
     if not re.match(r"^[\w\s'\-]+$", title):
         return False
 
     return True
+
+
+def validate_solution_summary(summary: str) -> bool:
+    return bool(summary) and len(summary) <= SOLUTION_SUMMARY_MAX_LENGTH
+
+
+def validate_solution_platform(platform: str) -> bool:
+    return platform in SUPPORTED_PLATFORMS
 
 
 def register_solution_package(
@@ -137,9 +150,31 @@ def register_solution_package(
                 {
                     "code": "invalid-title",
                     "message": "Title format is invalid. "
-                    "It should only have ASCII lowercase letters, "
-                    "numbers, and hyphens, and must have "
-                    "at least one letter",
+                    f"It must be {SOLUTION_TITLE_MAX_LENGTH} characters "
+                    "or fewer and only contain ASCII lowercase letters, "
+                    "numbers, spaces and hyphens.",
+                }
+            ]
+        )
+
+    if not validate_solution_summary(summary):
+        raise ValidationError(
+            [
+                {
+                    "code": "invalid-summary",
+                    "message": "Summary is required and must be "
+                    f"{SOLUTION_SUMMARY_MAX_LENGTH} characters or fewer.",
+                }
+            ]
+        )
+
+    if not validate_solution_platform(platform):
+        raise ValidationError(
+            [
+                {
+                    "code": "invalid-platform",
+                    "message": "Platform must be one of: "
+                    f"{', '.join(sorted(SUPPORTED_PLATFORMS))}.",
                 }
             ]
         )
@@ -527,6 +562,34 @@ def update_draft_solution(solution, metadata):
     return serialize_solution(solution)
 
 
+def validate_solution_metadata(metadata: dict):
+    if "title" in metadata and not validate_solution_title(metadata["title"]):
+        raise ValidationError(
+            [
+                {
+                    "code": "invalid-title",
+                    "message": "Title format is invalid. "
+                    f"It must be {SOLUTION_TITLE_MAX_LENGTH} characters "
+                    "or fewer and only contain ASCII lowercase letters, "
+                    "numbers, spaces and hyphens.",
+                }
+            ]
+        )
+
+    if "summary" in metadata and not validate_solution_summary(
+        metadata["summary"]
+    ):
+        raise ValidationError(
+            [
+                {
+                    "code": "invalid-summary",
+                    "message": "Summary is required and must be "
+                    f"{SOLUTION_SUMMARY_MAX_LENGTH} characters or fewer.",
+                }
+            ]
+        )
+
+
 def update_solution_metadata(name: str, rev: int, metadata: dict):
     """
     Update solution metadata for a specific revision.
@@ -545,6 +608,8 @@ def update_solution_metadata(name: str, rev: int, metadata: dict):
 
     if not solution:
         return None
+
+    validate_solution_metadata(metadata)
 
     if solution.status not in [
         SolutionStatus.DRAFT,

--- a/app/publisher/logic.py
+++ b/app/publisher/logic.py
@@ -151,8 +151,8 @@ def register_solution_package(
                     "code": "invalid-title",
                     "message": "Title format is invalid. "
                     f"It must be {SOLUTION_TITLE_MAX_LENGTH} characters "
-                    "or fewer and only contain ASCII lowercase letters, "
-                    "numbers, spaces and hyphens.",
+                    "or fewer and only contain letters, numbers, spaces, "
+                    "apostrophes, underscores, and hyphens.",
                 }
             ]
         )
@@ -570,8 +570,8 @@ def validate_solution_metadata(metadata: dict):
                     "code": "invalid-title",
                     "message": "Title format is invalid. "
                     f"It must be {SOLUTION_TITLE_MAX_LENGTH} characters "
-                    "or fewer and only contain ASCII lowercase letters, "
-                    "numbers, spaces and hyphens.",
+                    "or fewer and only contain letters, numbers, spaces, "
+                    "apostrophes, underscores, and hyphens.",
                 }
             ]
         )

--- a/app/publisher/logic.py
+++ b/app/publisher/logic.py
@@ -119,7 +119,7 @@ def validate_solution_summary(summary: str) -> bool:
 
 
 def validate_solution_platform(platform: str) -> bool:
-    return platform in SUPPORTED_PLATFORMS
+    return bool(platform) and platform.lower() in SUPPORTED_PLATFORMS
 
 
 def register_solution_package(

--- a/app/reviewer/logic.py
+++ b/app/reviewer/logic.py
@@ -11,8 +11,16 @@ from app.utils import serialize_solution
 
 
 def approve_solution_name(name: str, reviewer_id: str):
-    solution = db.session.query(Solution).filter(Solution.name == name).first()
-    if solution and solution.status == SolutionStatus.PENDING_NAME_REVIEW:
+    solution = (
+        db.session.query(Solution)
+        .filter(
+            Solution.name == name,
+            Solution.status == SolutionStatus.PENDING_NAME_REVIEW,
+        )
+        .order_by(Solution.revision.desc())
+        .first()
+    )
+    if solution:
         solution.status = SolutionStatus.DRAFT
         solution.approved_by = reviewer_id
         review_action = ReviewAction(
@@ -28,8 +36,16 @@ def approve_solution_name(name: str, reviewer_id: str):
 
 
 def approve_solution_metadata(name: str, reviewer_id: str):
-    solution = db.session.query(Solution).filter(Solution.name == name).first()
-    if solution and solution.status == SolutionStatus.PENDING_METADATA_REVIEW:
+    solution = (
+        db.session.query(Solution)
+        .filter(
+            Solution.name == name,
+            Solution.status == SolutionStatus.PENDING_METADATA_REVIEW,
+        )
+        .order_by(Solution.revision.desc())
+        .first()
+    )
+    if solution:
         # Unpublish previous revision
         (
             db.session.query(Solution)

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,8 +1,10 @@
 from app.models import Solution
 
 
-def serialize_solution(solution: Solution) -> dict:
-    return {
+def serialize_solution(
+    solution: Solution, include_private: bool = True
+) -> dict:
+    data = {
         "id": solution.id,
         "name": solution.name,
         "hash": solution.hash,
@@ -49,20 +51,21 @@ def serialize_solution(solution: Solution) -> dict:
         "charms": [c.to_dict() for c in solution.charms],
         "maintainers": [m.to_dict() for m in solution.maintainers],
         "useful_links": [ul.to_dict() for ul in solution.useful_links],
-        "creator": (
+    }
+
+    if include_private:
+        data["creator"] = (
             {
                 "email": solution.creator.email,
                 "mattermost_handle": solution.creator.mattermost_handle,
             }
             if solution.creator
             else None
-        ),
-        "approved_by": solution.approved_by,
-    }
+        )
+        data["approved_by"] = solution.approved_by
+
+    return data
 
 
 def serialize_public_solution(solution: Solution) -> dict:
-    data = serialize_solution(solution)
-    data.pop("creator", None)
-    data.pop("approved_by", None)
-    return data
+    return serialize_solution(solution, include_private=False)

--- a/app/utils.py
+++ b/app/utils.py
@@ -59,3 +59,10 @@ def serialize_solution(solution: Solution) -> dict:
         ),
         "approved_by": solution.approved_by,
     }
+
+
+def serialize_public_solution(solution: Solution) -> dict:
+    data = serialize_solution(solution)
+    data.pop("creator", None)
+    data.pop("approved_by", None)
+    return data

--- a/config.py
+++ b/config.py
@@ -13,8 +13,8 @@ class Config:
     SECRET_KEY = os.getenv(
         "FLASK_SECRET_KEY", "dev-secret-key"
     )
-    OPENID_LAUNCHPAD_TEAM = os.getenv(
-        "OPENID_LAUNCHPAD_TEAM", "charmhub-solution-reviewers"
+    FLASK_OPENID_LAUNCHPAD_TEAM = os.getenv(
+        "FLASK_OPENID_LAUNCHPAD_TEAM", "charmhub-solution-reviewers"
     )
     CHARMHUB_URL = os.getenv(
         "FLASK_CHARMHUB_URL", "http://localhost:8045"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,11 +4,12 @@ services:
     ports:
       - "5000:5000"
     env_file: .env
-    command:
-      - 0.0.0.0
-      - "5000"
+    environment:
+      SEED_DB: "true"
+    command: flask run --host=0.0.0.0 --port=5000
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     volumes:
       - .:/app
 
@@ -17,6 +18,11 @@ services:
     env_file: .env
     ports:
       - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 1s
+      timeout: 5s
+      retries: 30
     volumes:
       - postgres_data:/var/lib/postgresql/data
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,12 @@
 # Exit on error
 set -e
 
+# Wait for database to accept connections
+until python -c 'import os, psycopg2; psycopg2.connect(os.environ["POSTGRESQL_DB_CONNECT_STRING"]).close()'; do
+  echo "Waiting for database..."
+  sleep 1
+done
+
 # Apply database migrations
 flask db upgrade
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,24 +3,12 @@
 # Exit on error
 set -e
 
-# Wait for database to accept connections (max ~60s by default)
-max_retries="${DB_WAIT_RETRIES:-60}"
-i=0
-until python -c 'import os, psycopg2; psycopg2.connect(os.environ["POSTGRESQL_DB_CONNECT_STRING"]).close()'; do
-  i=$((i + 1))
-  if [ "$i" -ge "$max_retries" ]; then
-    echo "Database not ready after ${max_retries}s, exiting." >&2
-    exit 1
-  fi
-  echo "Waiting for database..."
-  sleep 1
-done
+if [ -n "$POSTGRESQL_DB_CONNECT_STRING" ]; then
+	python3 migrate.py
+fi
 
-# Apply database migrations
-flask db upgrade
+if [ "$SEED_DB" = "true" ]; then
+	python3 -m seed
+fi
 
-# Seed the database
-python -m seed
-
-# Start the application
-flask run --host=$1 --port=$2
+exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,8 +3,15 @@
 # Exit on error
 set -e
 
-# Wait for database to accept connections
+# Wait for database to accept connections (max ~60s by default)
+max_retries="${DB_WAIT_RETRIES:-60}"
+i=0
 until python -c 'import os, psycopg2; psycopg2.connect(os.environ["POSTGRESQL_DB_CONNECT_STRING"]).close()'; do
+  i=$((i + 1))
+  if [ "$i" -ge "$max_retries" ]; then
+    echo "Database not ready after ${max_retries}s, exiting." >&2
+    exit 1
+  fi
   echo "Waiting for database..."
   sleep 1
 done

--- a/tests/test_publisher_logic.py
+++ b/tests/test_publisher_logic.py
@@ -3,7 +3,8 @@ from unittest.mock import Mock, patch
 from app.publisher.logic import (
     find_or_create_creator,
     register_solution_package,
-    create_empty_solution
+    create_empty_solution,
+    validate_solution_metadata,
 )
 from app.models import Creator
 from app.exceptions import ValidationError
@@ -89,6 +90,52 @@ class TestRegisterSolutionPackage:
         errors = exc_info.value.errors
         assert len(errors) == 1
         assert errors[0]["code"] == "invalid-name"
+
+    def test_name_max_length_validation(self):
+        mock_creator = Mock(id=1)
+        with pytest.raises(ValidationError) as exc_info:
+            register_solution_package(
+                teams=["test-team"],
+                name="a" * 41,
+                publisher="test-team",
+                summary="Test summary",
+                creator=mock_creator,
+            )
+
+        assert exc_info.value.errors[0]["code"] == "invalid-name"
+
+    def test_summary_max_length_validation(self):
+        mock_creator = Mock(id=1)
+        with pytest.raises(ValidationError) as exc_info:
+            register_solution_package(
+                teams=["test-team"],
+                name="valid-name",
+                publisher="test-team",
+                summary="a" * 501,
+                creator=mock_creator,
+            )
+
+        assert exc_info.value.errors[0]["code"] == "invalid-summary"
+
+    def test_invalid_platform_validation(self):
+        mock_creator = Mock(id=1)
+        with pytest.raises(ValidationError) as exc_info:
+            register_solution_package(
+                teams=["test-team"],
+                name="valid-name",
+                publisher="test-team",
+                summary="Test summary",
+                creator=mock_creator,
+                platform="invalid-platform",
+            )
+
+        assert exc_info.value.errors[0]["code"] == "invalid-platform"
+
+    def test_metadata_title_max_length_validation(self):
+        with pytest.raises(ValidationError) as exc_info:
+            validate_solution_metadata({"title": "a" * 41})
+
+        assert exc_info.value.errors[0]["code"] == "invalid-title"
 
     @patch("app.publisher.logic.get_solution_by_name")
     def test_already_exists_validation(self, mock_get_solution):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,55 @@
+from types import SimpleNamespace
+
+from app.utils import serialize_public_solution
+
+
+def test_public_serializer_excludes_private_fields():
+    solution = SimpleNamespace(
+        id=1,
+        name="test-solution",
+        hash="abc123",
+        revision=1,
+        status=SimpleNamespace(value="published"),
+        visibility=SimpleNamespace(value="public"),
+        title="Test Solution",
+        summary="Summary",
+        description="Description",
+        terraform_modules=[],
+        created=SimpleNamespace(isoformat=lambda: "2026-01-01T00:00:00"),
+        last_updated=SimpleNamespace(
+            isoformat=lambda: "2026-01-01T00:00:00"
+        ),
+        publisher=SimpleNamespace(
+            publisher_id="publisher-id",
+            display_name="Publisher",
+            username="publisher",
+        ),
+        use_cases=[],
+        platform=SimpleNamespace(value="kubernetes"),
+        platform_version=[],
+        platform_prerequisites=[],
+        juju_versions=[],
+        documentation_main=None,
+        documentation_source=None,
+        get_started_url=None,
+        how_to_operate_url=None,
+        architecture_explanation=None,
+        submit_bug_url=None,
+        community_discussion_url=None,
+        icon=None,
+        architecture_diagram_url=None,
+        charms=[],
+        maintainers=[],
+        useful_links=[],
+        creator=SimpleNamespace(
+            email="creator@example.com",
+            mattermost_handle="creator-handle",
+        ),
+        approved_by="reviewer@example.com",
+    )
+
+    data = serialize_public_solution(solution)
+
+    assert data["name"] == "test-solution"
+    assert "creator" not in data
+    assert "approved_by" not in data

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -41,11 +41,6 @@ def test_public_serializer_excludes_private_fields():
         charms=[],
         maintainers=[],
         useful_links=[],
-        creator=SimpleNamespace(
-            email="creator@example.com",
-            mattermost_handle="creator-handle",
-        ),
-        approved_by="reviewer@example.com",
     )
 
     data = serialize_public_solution(solution)


### PR DESCRIPTION
## Done
This PR applies a set of health check updates before we release the solutions service to the world:
- Split public solution serialization so unauthenticated public endpoints no longer expose creator contact details or reviewer approval data
- Improved reviewer approval lookups - filter by the expected pending status instead of just approving the first solution that matches a name
- Added validation for solution name / title length, summary length and supported platform values
- Added Launchpad request timeout as a constant to be reused
- Renamed `OPENID_LAUNCHPAD_TEAM` key to `FLASK_OPENID_LAUNCHPAD_TEAM` in `config.py`
- Added DB readiness wait (it kept trying to run migrations before the container had started up)

## How to QA
- Check out this branch and run it with `docker compose up --build`
- Run tests with `docker compose exec solutions-service python3 -m pytest tests/` - make sure they pass
- In general, make sure logic works (try to approve / review some solutions)
- For preview functionality, you'll have to run charmhub locally (use the branch in [this PR](https://github.com/canonical/charmhub.io/pull/2348) for QA)
- To QA the API not returning creator details:
  - go to http://localhost:5000/api/solutions and make sure there are no creator / reviewer details
  - compare this to [prod currently](https://solutions.charmhub.io/api/solutions) where this data is exposed
- Running charmhub locally, try to register a solution with:
  - name longer than 40 characters
  - title longer than 40 characters
  - summary longer than 500 characters
  - make sure they fail

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes [WD-36750](https://warthogs.atlassian.net/browse/WD-36750)

[WD-36750]: https://warthogs.atlassian.net/browse/WD-36750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ