### PR TITLE
remove how_to_operate url

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -101,7 +101,6 @@ class Solution(db.Model):
     # github source repo
     documentation_source: Mapped[Optional[str]] = mapped_column(String)
     get_started_url: Mapped[Optional[str]] = mapped_column(String)
-    how_to_operate_url: Mapped[Optional[str]] = mapped_column(String)
     architecture_diagram_url: Mapped[Optional[str]] = mapped_column(String)
     architecture_explanation: Mapped[Optional[str]] = mapped_column(Text)
     submit_bug_url: Mapped[Optional[str]] = mapped_column(String)

--- a/app/templates/review_solution.html
+++ b/app/templates/review_solution.html
@@ -119,12 +119,7 @@
                                 <strong>Get Started:</strong> <a href="{{ solution.get_started_url }}" target="_blank">{{ solution.get_started_url }}</a>
                             </p>
                         {% endif %}
-                        {% if solution.how_to_operate_url %}
-                            <p>
-                                <strong>How to Operate:</strong> <a href="{{ solution.how_to_operate_url }}" target="_blank">{{ solution.how_to_operate_url }}</a>
-                            </p>
-                        {% endif %}
-                        {% if not solution.documentation_main and not solution.documentation_source and not solution.get_started_url and not solution.how_to_operate_url %}
+                        {% if not solution.documentation_main and not solution.documentation_source and not solution.get_started_url %}
                             <p>No documentation specified</p>
                         {% endif %}
                         <hr>

--- a/app/utils.py
+++ b/app/utils.py
@@ -39,7 +39,6 @@ def serialize_solution(
             "main": solution.documentation_main,
             "source": solution.documentation_source,
             "get_started": solution.get_started_url,
-            "how_to_operate": solution.how_to_operate_url,
             "architecture_explanation": solution.architecture_explanation,
             "submit_a_bug": solution.submit_bug_url,
             "community_discussion": solution.community_discussion_url,

--- a/migrations/versions/7d6efdfd9c2a_remove_how_to_operate_url.py
+++ b/migrations/versions/7d6efdfd9c2a_remove_how_to_operate_url.py
@@ -1,0 +1,28 @@
+"""Remove how_to_operate_url from solutions
+
+Revision ID: 7d6efdfd9c2a
+Revises: 44deb5318b78
+Create Date: 2026-06-09 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "7d6efdfd9c2a"
+down_revision = "44deb5318b78"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("solution", schema=None) as batch_op:
+        batch_op.drop_column("how_to_operate_url")
+
+
+def downgrade():
+    with op.batch_alter_table("solution", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column("how_to_operate_url", sa.String(), nullable=True)
+        )

--- a/seed.py
+++ b/seed.py
@@ -81,7 +81,6 @@ def seed_database():
                     "main": "https://documentation.ubuntu.com/observability/",
                     "source": "https://github.com/canonical/observability/",
                     "get_started": "https://documentation.ubuntu.com/observability/tutorial/",
-                    "how_to_operate": "https://documentation.ubuntu.com/observability/how-to/",
                     "architecture_explanation": "this is an explanation of how COS works",
                     "submit_a_bug": "https://github.com/canonical/observability-docs/issues/new?title=docs%3A+TYPE+YOUR+QUESTION+HERE&body=*Please%20describe%20the%20question%20or%20issue%20you%27re%20facing%20with%20%22Observability%20Documentation%22.*%0A%0A%0A%0A%0A---%0A*Reported+from%3A+https://charmhub.io*",
                     "community_discussion": "https://discourse.charmhub.io/c/charm/observability/62",
@@ -178,7 +177,6 @@ def seed_database():
                     "main": "https://canonical.com/solutions/telco",
                     "source": "https://github.com/canonical/telco/",
                     "get_started": "https://documentation.ubuntu.com/telco/tutorial/",
-                    "how_to_operate": "https://documentation.ubuntu.com/telco/how-to/",
                     "architecture_explanation": "",
                     "submit_a_bug": "https://github.com/canonical/telco",
                     "community_discussion": "https://discourse.ubuntu.com",
@@ -262,7 +260,6 @@ def seed_database():
                 "documentation": {
                     "source": "https://github.com/canonical/charmed-kubeflow-solutions",
                     "get_started": "https://charmed-kubeflow.io/docs/get-started",
-                    "how_to_operate": "https://charmed-kubeflow.io/docs/how-to",
                     "architecture_explanation": "",
                     "submit_a_bug": "https://github.com/canonical/bundle-kubeflow",
                     "community_discussion": "https://discourse.charmhub.io/tag/kubeflow",
@@ -388,7 +385,6 @@ def seed_database():
                 documentation_main=data.get("documentation", {}).get("main", ""),
                 documentation_source=data.get("documentation", {}).get("source", ""),
                 get_started_url=data.get("documentation", {}).get("get_started", ""),
-                how_to_operate_url=data.get("documentation", {}).get("how_to_operate", ""),
                 architecture_diagram_url=data["media"]["architecture_diagram"],
                 architecture_explanation=data.get("documentation", {}).get(
                     "architecture_explanation", ""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -32,7 +32,6 @@ def test_public_serializer_excludes_private_fields():
         documentation_main=None,
         documentation_source=None,
         get_started_url=None,
-        how_to_operate_url=None,
         architecture_explanation=None,
         submit_bug_url=None,
         community_discussion_url=None,


### PR DESCRIPTION
## Done
- Removes how_to_operate url - this got mixed up in the useful_links, there was never meant to be a how_to_operate of its own

## How to QA
- Run solutions locally against [this branch](https://github.com/canonical/charmhub.io/pull/2354) of charmhub locally
- Try to edit a solution and make sure there is no how to operate URL there

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):
