### PR TITLE
add save draft functionality

### DIFF
--- a/app/public/logic.py
+++ b/app/public/logic.py
@@ -68,10 +68,11 @@ def get_published_solution_by_hash(hash: str):
     ):
         return serialize_public_solution(solution)
 
-    # allow previewing pending solutions (for review dashboard)
+    # allow previewing pending and draft solutions
     if solution.status in [
         SolutionStatus.PENDING_NAME_REVIEW,
         SolutionStatus.PENDING_METADATA_REVIEW,
+        SolutionStatus.DRAFT,
     ]:
         return serialize_public_solution(solution)
 

--- a/app/publisher/api.py
+++ b/app/publisher/api.py
@@ -1,9 +1,11 @@
 from flask import Blueprint, jsonify, g, request
+from app.extensions import db
 from app.publisher.logic import (
     get_solutions_by_lp_teams,
     create_new_solution_revision,
     get_draft_solution_by_name,
     get_solution_by_name_and_rev,
+    get_publisher_solution_by_hash,
     update_solution_metadata,
     register_solution_package,
     find_or_create_creator,
@@ -26,6 +28,21 @@ def get_publisher_solutions():
 
     solutions = get_solutions_by_lp_teams(teams)
     return jsonify(solutions), 200
+
+
+@publisher_bp.route("/solutions/by-hash/<string:hash>", methods=["GET"])
+@login_required
+def get_publisher_solution(hash):
+    user = g.user
+    teams = g.user["teams"]
+    if not teams:
+        teams = get_user_teams(user["username"])
+
+    solution = get_publisher_solution_by_hash(hash, teams)
+    if not solution:
+        return jsonify({"error": "Solution not found"}), 404
+
+    return jsonify(solution), 200
 
 
 @publisher_bp.route("/solutions", methods=["POST"])
@@ -123,10 +140,12 @@ def create_solution_revision(name):
         data.get("mattermost_handle"),
     )
 
-    solution = create_new_solution_revision(
-        name=name,
-        creator=creator,
-    )
+    try:
+        solution = create_new_solution_revision(name=name, creator=creator)
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+        raise
 
     return jsonify(solution), 200
 
@@ -150,8 +169,15 @@ def update_solution_revision(name, rev):
     if not data:
         return jsonify({"error": "No data provided"}), 400
 
+    submit_for_review = data.pop("submit_for_review", True)
+
     try:
-        updated_solution = update_solution_metadata(name, rev, data)
+        updated_solution = update_solution_metadata(
+            name,
+            rev,
+            data,
+            submit_for_review=submit_for_review,
+        )
     except ValidationError as e:
         return jsonify({"error-list": e.errors}), 400
 

--- a/app/publisher/logic.py
+++ b/app/publisher/logic.py
@@ -20,6 +20,7 @@ from app.exceptions import ValidationError
 import uuid
 import re
 from sqlalchemy import inspect
+from sqlalchemy.exc import IntegrityError
 from datetime import datetime, timezone
 
 
@@ -314,31 +315,25 @@ def create_new_solution_revision(
     if not current_solution:
         return None
 
-    try:
+    mapper = inspect(Solution)
+    data = {}
+    for column in mapper.columns:
+        if column.key not in ["id"]:
+            data[column.key] = getattr(current_solution, column.key)
 
-        mapper = inspect(Solution)
-        data = {}
-        for column in mapper.columns:
-            if column.key not in ["id"]:
-                data[column.key] = getattr(current_solution, column.key)
+    data["hash"] = uuid.uuid4().hex[:16]
+    data["revision"] = current_solution.revision + 1
+    data["status"] = SolutionStatus.DRAFT
+    data["creator_id"] = creator.id  # Set the new creator for this revision
 
-        data["hash"] = uuid.uuid4().hex[:16]
-        data["revision"] = current_solution.revision + 1
-        data["status"] = SolutionStatus.DRAFT
-        data["creator_id"] = creator.id  # Set the new creator for this revision
-
-        new_solution = Solution(**data)
-        db.session.add(new_solution)
-        db.session.commit()
-        return serialize_solution(new_solution)
-
-    except Exception:
-        db.session.rollback()
-        raise
+    new_solution = Solution(**data)
+    db.session.add(new_solution)
+    db.session.flush()
+    return serialize_solution(new_solution)
 
 
-def get_draft_solution_by_name(name: str):
-    solution = (
+def find_draft_solution_by_name(name: str):
+    return (
         db.session.query(Solution)
         .filter(
             Solution.name == name,
@@ -346,6 +341,10 @@ def get_draft_solution_by_name(name: str):
         )
         .first()
     )
+
+
+def get_draft_solution_by_name(name: str):
+    solution = find_draft_solution_by_name(name)
     return serialize_solution(solution) if solution else None
 
 
@@ -359,6 +358,41 @@ def get_solution_by_name_and_rev(name: str, rev: int):
         .first()
     )
     return serialize_solution(solution) if solution else None
+
+
+def get_publisher_solution_by_hash(hash: str, teams: list[str]):
+    """Fetch a single solution by hash, scoped to the user's teams.
+    When the solution is published and has an in-progress draft update, 
+    the draft summary is attached as ``draft_update``.
+    """
+    if not teams:
+        return None
+
+    solution = (
+        db.session.query(Solution)
+        .join(Publisher, Solution.publisher_id == Publisher.publisher_id)
+        .filter(
+            Solution.hash == hash,
+            Publisher.username.in_(teams),
+        )
+        .first()
+    )
+
+    if not solution:
+        return None
+
+    data = serialize_solution(solution)
+
+    if solution.status == SolutionStatus.PUBLISHED:
+        draft = find_draft_solution_by_name(solution.name)
+        if draft and draft.revision > 1:
+            data["draft_update"] = {
+                "hash": draft.hash,
+                "revision": draft.revision,
+                "last_updated": draft.last_updated,
+            }
+
+    return data
 
 
 def copy_charms_to_solution(
@@ -513,7 +547,7 @@ def update_published_solution(solution, metadata):
     return serialize_solution(new_solution)
 
 
-def update_draft_solution(solution, metadata):
+def update_draft_solution(solution, metadata, submit_for_review=True):
     charms_data = metadata.pop("charms", None)
     useful_links_data = metadata.pop("useful_links", None)
     use_cases_data = metadata.pop("use_cases", None)
@@ -551,15 +585,32 @@ def update_draft_solution(solution, metadata):
         solution, creator_email, mattermost_handle
     )
 
-    if solution.revision == 1:
-        solution.status = SolutionStatus.PENDING_METADATA_REVIEW
-    else:
-        solution.status = SolutionStatus.PUBLISHED
+    if submit_for_review:
+        if solution.revision == 1:
+            solution.status = SolutionStatus.PENDING_METADATA_REVIEW
+        else:
+            unpublish_other_published_revisions(solution)
+            solution.status = SolutionStatus.PUBLISHED
 
     solution.last_updated = datetime.now(timezone.utc)
 
     db.session.commit()
     return serialize_solution(solution)
+
+
+def unpublish_other_published_revisions(solution):
+    published_solutions = (
+        db.session.query(Solution)
+        .filter(
+            Solution.name == solution.name,
+            Solution.id != solution.id,
+            Solution.status == SolutionStatus.PUBLISHED,
+        )
+        .all()
+    )
+
+    for published_solution in published_solutions:
+        published_solution.status = SolutionStatus.UNPUBLISHED
 
 
 def validate_solution_metadata(metadata: dict):
@@ -590,12 +641,16 @@ def validate_solution_metadata(metadata: dict):
         )
 
 
-def update_solution_metadata(name: str, rev: int, metadata: dict):
+def update_solution_metadata(
+    name: str,
+    rev: int,
+    metadata: dict,
+    submit_for_review: bool = True,
+):
     """
     Update solution metadata for a specific revision.
-    For revision 1: sets status to PENDING_METADATA_REVIEW
-    For revision >1: sets status to PUBLISHED (update without review)
-    and increases revision number by 1
+    When submit_for_review is False, metadata is saved without changing
+    the solution status.
     """
     solution = (
         db.session.query(Solution)
@@ -609,7 +664,8 @@ def update_solution_metadata(name: str, rev: int, metadata: dict):
     if not solution:
         return None
 
-    validate_solution_metadata(metadata)
+    if submit_for_review:
+        validate_solution_metadata(metadata)
 
     if solution.status not in [
         SolutionStatus.DRAFT,
@@ -627,9 +683,37 @@ def update_solution_metadata(name: str, rev: int, metadata: dict):
 
     try:
         if solution.status == SolutionStatus.PUBLISHED:
-            return update_published_solution(solution, metadata)
-        else:
-            return update_draft_solution(solution, metadata)
+            draft_solution = find_draft_solution_by_name(name)
+
+            if submit_for_review:
+                if draft_solution:
+                    return update_draft_solution(
+                        draft_solution,
+                        metadata,
+                        submit_for_review=True,
+                    )
+
+                return update_published_solution(solution, metadata)
+
+            if not draft_solution:
+                try:
+                    with db.session.begin_nested():
+                        create_new_solution_revision(name, solution.creator)
+                except IntegrityError:
+                    pass
+                draft_solution = find_draft_solution_by_name(name)
+
+            return update_draft_solution(
+                draft_solution,
+                metadata,
+                submit_for_review=False,
+            )
+
+        return update_draft_solution(
+            solution,
+            metadata,
+            submit_for_review=submit_for_review,
+        )
 
     except Exception:
         db.session.rollback()

--- a/app/publisher/logic.py
+++ b/app/publisher/logic.py
@@ -389,7 +389,11 @@ def get_publisher_solution_by_hash(hash: str, teams: list[str]):
             data["draft_update"] = {
                 "hash": draft.hash,
                 "revision": draft.revision,
-                "last_updated": draft.last_updated,
+                "last_updated": (
+                    draft.last_updated.isoformat()
+                    if draft.last_updated
+                    else None
+                ),
             }
 
     return data

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -11,7 +11,7 @@
             <div class="u-fixed-width">
             {{ solution_table(published_solutions, "Published", charmhub_url) }}
             {{ solution_table(pending_metadata_review_solutions, "Pending Metadata Review", charmhub_url) }}
-            {{ solution_table(draft_solutions, "Pending Metadata Submission", charmhub_url) }}
+            {{ solution_table(draft_solutions, "Draft", charmhub_url) }}
             {{ solution_table(pending_name_review_solutions, "Pending Name Review", charmhub_url) }}
             {{ solution_table(unpublished_solutions, "Unpublished", charmhub_url) }}
             

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,7 +1,9 @@
 import pytest
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 from flask import Flask
 from app.public.api import public_bp
+from app.public.logic import get_published_solution_by_hash
+from app.models import SolutionStatus
 
 
 @pytest.fixture
@@ -117,3 +119,19 @@ def test_check_solution_name_does_not_exist(mock_solution, client):
     data = response.get_json()
     assert data["exists"] is False
     mock_solution.query.filter_by.assert_called_once_with(name="new-solution")
+
+
+@patch("app.public.logic.serialize_public_solution")
+@patch("app.public.logic.db.session")
+def test_get_published_solution_by_hash_serves_draft(
+    mock_session, mock_serialize_public_solution
+):
+
+    draft_solution = Mock(status=SolutionStatus.DRAFT)
+    mock_session.query().filter().first.return_value = draft_solution
+    mock_serialize_public_solution.return_value = {"status": "draft"}
+
+    result = get_published_solution_by_hash("randomhash")
+
+    assert result == {"status": "draft"}
+    mock_serialize_public_solution.assert_called_once_with(draft_solution)

--- a/tests/test_publisher_api.py
+++ b/tests/test_publisher_api.py
@@ -57,6 +57,62 @@ def test_get_publisher_solutions(
 
 @patch("app.public.auth.get_user_teams")
 @patch("app.public.auth.decode_jwt_token")
+@patch("app.publisher.api.get_publisher_solution_by_hash")
+def test_get_publisher_solution_by_hash(
+    mock_get_publisher_solution_by_hash,
+    mock_decode_jwt_token,
+    mock_get_user_teams,
+    client,
+):
+    mock_decode_jwt_token.return_value = {"sub": "testuser"}
+    mock_get_user_teams.return_value = ["team1", "team2"]
+    mock_get_publisher_solution_by_hash.return_value = {
+        "name": "test-solution",
+        "hash": "abc123",
+        "status": "published",
+        "draft_update": {"hash": "def456", "revision": 2},
+    }
+
+    response = client.get(
+        "/api/publisher/solutions/by-hash/abc123",
+        headers={"Authorization": "Bearer fake token"},
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["hash"] == "abc123"
+    assert data["draft_update"]["hash"] == "def456"
+    mock_get_publisher_solution_by_hash.assert_called_once_with(
+        "abc123", ["team1", "team2"]
+    )
+
+
+@patch("app.public.auth.get_user_teams")
+@patch("app.public.auth.decode_jwt_token")
+@patch("app.publisher.api.get_publisher_solution_by_hash")
+def test_get_publisher_solution_by_hash_not_found(
+    mock_get_publisher_solution_by_hash,
+    mock_decode_jwt_token,
+    mock_get_user_teams,
+    client,
+):
+    mock_decode_jwt_token.return_value = {"sub": "testuser"}
+    mock_get_user_teams.return_value = ["team1"]
+    mock_get_publisher_solution_by_hash.return_value = None
+
+    response = client.get(
+        "/api/publisher/solutions/by-hash/missing",
+        headers={"Authorization": "Bearer fake token"},
+    )
+
+    assert response.status_code == 404
+    mock_get_publisher_solution_by_hash.assert_called_once_with(
+        "missing", ["team1"]
+    )
+
+
+@patch("app.public.auth.get_user_teams")
+@patch("app.public.auth.decode_jwt_token")
 @patch("app.publisher.api.find_or_create_creator")
 @patch("app.publisher.api.register_solution_package")
 def test_register_solution(
@@ -189,6 +245,7 @@ def test_update_solution_revision_1(
         "test-solution",
         1,
         {"title": "Updated Title", "description": "Updated description"},
+        submit_for_review=True,
     )
 
 
@@ -230,6 +287,53 @@ def test_update_solution_revision_greater_than_1(
     data = response.get_json()
     assert data["title"] == "Updated Title"
     assert data["status"] == "published"
+    mock_update_solution_metadata.assert_called_once_with(
+        "test-solution",
+        2,
+        {"title": "Updated Title"},
+        submit_for_review=True,
+    )
+
+
+@patch("app.public.auth.get_user_teams")
+@patch("app.public.auth.decode_jwt_token")
+@patch("app.publisher.api.update_solution_metadata")
+@patch("app.publisher.api.get_solution_by_name_and_rev")
+def test_update_solution_revision_save_draft(
+    mock_get_solution_by_name_and_rev,
+    mock_update_solution_metadata,
+    mock_decode_jwt_token,
+    mock_get_user_teams,
+    client,
+):
+    mock_decode_jwt_token.return_value = {"sub": "testuser"}
+    mock_get_user_teams.return_value = ["team1"]
+    mock_get_solution_by_name_and_rev.return_value = {
+        "name": "test-solution",
+        "revision": 2,
+        "publisher": {"username": "team1"},
+    }
+    mock_update_solution_metadata.return_value = {
+        "name": "test-solution",
+        "revision": 2,
+        "status": "draft",
+        "title": "Draft title",
+    }
+
+    response = client.patch(
+        "/api/publisher/solutions/test-solution/2",
+        json={"title": "Draft title", "submit_for_review": False},
+        headers={"Authorization": "Bearer fake token"},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["status"] == "draft"
+    mock_update_solution_metadata.assert_called_once_with(
+        "test-solution",
+        2,
+        {"title": "Draft title"},
+        submit_for_review=False,
+    )
 
 
 @patch("app.public.auth.get_user_teams")

--- a/tests/test_publisher_logic.py
+++ b/tests/test_publisher_logic.py
@@ -5,8 +5,9 @@ from app.publisher.logic import (
     register_solution_package,
     create_empty_solution,
     validate_solution_metadata,
+    update_solution_metadata,
 )
-from app.models import Creator
+from app.models import Creator, SolutionStatus
 from app.exceptions import ValidationError
 
 
@@ -192,6 +193,48 @@ class TestRegisterSolutionPackage:
 
         mock_create_solution.assert_called_once()
         assert result == {"name": "test-solution"}
+
+
+class TestUpdateSolutionMetadata:
+    @patch("app.publisher.logic.update_published_solution")
+    @patch("app.publisher.logic.update_draft_solution")
+    @patch("app.publisher.logic.find_draft_solution_by_name")
+    @patch("app.publisher.logic.validate_solution_metadata")
+    @patch("app.publisher.logic.db.session")
+    def test_published_update_reuses_existing_draft(
+        self,
+        mock_session,
+        mock_validate_solution_metadata,
+        mock_find_draft_solution_by_name,
+        mock_update_draft_solution,
+        mock_update_published_solution,
+    ):
+        published_solution = Mock(status=SolutionStatus.PUBLISHED)
+        draft_solution = Mock(status=SolutionStatus.DRAFT)
+        metadata = {"title": "Updated Title"}
+
+        mock_session.query().filter().first.return_value = published_solution
+        mock_find_draft_solution_by_name.return_value = draft_solution
+        mock_update_draft_solution.return_value = {
+            "revision": 2,
+            "status": "published",
+        }
+
+        result = update_solution_metadata(
+            "test-solution",
+            1,
+            metadata,
+            submit_for_review=True,
+        )
+
+        assert result == {"revision": 2, "status": "published"}
+        mock_validate_solution_metadata.assert_called_once_with(metadata)
+        mock_update_draft_solution.assert_called_once_with(
+            draft_solution,
+            metadata,
+            submit_for_review=True,
+        )
+        mock_update_published_solution.assert_not_called()
 
 
 class TestTransactionSafety:


### PR DESCRIPTION
## Done
- Add logic to allow a publisher to save a draft solution and come back at a later date to finish editing
- Optimises hash logic for faster lookup when previewing a specific solution
- Matching frontend logic in https://github.com/canonical/charmhub.io/pull/2372

## How to QA
- Follow the QA steps on [this PR](https://github.com/canonical/charmhub.io/pull/2372)

## Testing
- [x] This PR has tests