### PR TITLE
add categories logic to solutions

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -109,6 +109,9 @@ class Solution(db.Model):
     # compatibility with juju versions
     juju_versions: Mapped[Optional[List[str]]] = mapped_column(JSON)
 
+    # list of category slugs (mirrors charm categories, min 1 / max 2)
+    categories: Mapped[Optional[List[str]]] = mapped_column(JSON)
+
     publisher_id: Mapped[str] = mapped_column(
         ForeignKey("publisher.publisher_id"), nullable=False
     )

--- a/app/publisher/logic.py
+++ b/app/publisher/logic.py
@@ -40,11 +40,14 @@ EDITABLE_FIELDS = {
     "platform_version",
     "platform_prerequisites",
     "juju_versions",
+    "categories",
 }
 
 SOLUTION_NAME_MAX_LENGTH = 40
 SOLUTION_TITLE_MAX_LENGTH = 40
 SOLUTION_SUMMARY_MAX_LENGTH = 500
+SOLUTION_CATEGORIES_MIN = 1
+SOLUTION_CATEGORIES_MAX = 2
 SUPPORTED_PLATFORMS = {platform.value for platform in PlatformTypes}
 
 
@@ -121,6 +124,14 @@ def validate_solution_summary(summary: str) -> bool:
 
 def validate_solution_platform(platform: str) -> bool:
     return bool(platform) and platform.lower() in SUPPORTED_PLATFORMS
+
+
+def validate_solution_categories(categories) -> bool:
+    return isinstance(categories, list) and (
+        SOLUTION_CATEGORIES_MIN
+        <= len(categories)
+        <= SOLUTION_CATEGORIES_MAX
+    )
 
 
 def register_solution_package(
@@ -644,6 +655,18 @@ def validate_solution_metadata(metadata: dict):
             ]
         )
 
+    if not validate_solution_categories(metadata.get("categories")):
+        raise ValidationError(
+            [
+                {
+                    "code": "invalid-categories",
+                    "message": "Please select between "
+                    f"{SOLUTION_CATEGORIES_MIN} and "
+                    f"{SOLUTION_CATEGORIES_MAX} categories.",
+                }
+            ]
+        )
+
 
 def update_solution_metadata(
     name: str,
@@ -669,6 +692,9 @@ def update_solution_metadata(
         return None
 
     if submit_for_review:
+        # categories are required on submit
+        if "categories" not in metadata:
+            metadata["categories"] = solution.categories or []
         validate_solution_metadata(metadata)
 
     if solution.status not in [

--- a/app/utils.py
+++ b/app/utils.py
@@ -35,6 +35,7 @@ def serialize_solution(
         "compatibility": {
             "juju_versions": solution.juju_versions or [],
         },
+        "categories": solution.categories or [],
         "documentation": {
             "main": solution.documentation_main,
             "source": solution.documentation_source,

--- a/migrations/versions/b1f2c3d4e5a6_add_categories_to_solution.py
+++ b/migrations/versions/b1f2c3d4e5a6_add_categories_to_solution.py
@@ -1,0 +1,28 @@
+"""Add categories to solution
+
+Revision ID: b1f2c3d4e5a6
+Revises: 7d6efdfd9c2a
+Create Date: 2026-07-01 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "b1f2c3d4e5a6"
+down_revision = "7d6efdfd9c2a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("solution", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column("categories", sa.JSON(), nullable=True)
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("solution", schema=None) as batch_op:
+        batch_op.drop_column("categories")

--- a/seed.py
+++ b/seed.py
@@ -102,6 +102,7 @@ def seed_database():
                     {"name": "tempo-coordinator-k8s"},
                 ],
                 "compatibility": {"juju_versions": [">=3.0"]},
+                "categories": ["logging-tracing", "monitoring"],
                 "maintainers": [
                     {
                         "display_name": "maintainerA",
@@ -200,6 +201,7 @@ def seed_database():
                     {"name": "sdcore-upf-k8s"},
                 ],
                 "compatibility": {"juju_versions": [">=3.0.3"]},
+                "categories": ["networking"],
                 "maintainers": [
                     {
                         "display_name": "maintainerB",
@@ -304,6 +306,7 @@ def seed_database():
                     {"name": "training-operator"},
                 ],
                 "compatibility": {"juju_versions": [">=3.1.0"]},
+                "categories": ["ai-ml"],
                 "maintainers": [
                     {
                         "display_name": "maintainerC",
@@ -394,6 +397,7 @@ def seed_database():
                     "community_discussion", ""
                 ),
                 juju_versions=data["compatibility"]["juju_versions"],
+                categories=data.get("categories"),
                 publisher_id=publisher.publisher_id,
                 creator_id=creator.id,
                 maintainers=maintainers,

--- a/tests/test_publisher_logic.py
+++ b/tests/test_publisher_logic.py
@@ -5,6 +5,7 @@ from app.publisher.logic import (
     register_solution_package,
     create_empty_solution,
     validate_solution_metadata,
+    validate_solution_categories,
     update_solution_metadata,
 )
 from app.models import Creator, SolutionStatus
@@ -138,6 +139,38 @@ class TestRegisterSolutionPackage:
 
         assert exc_info.value.errors[0]["code"] == "invalid-title"
 
+    def test_metadata_categories_required(self):
+        with pytest.raises(ValidationError) as exc_info:
+            validate_solution_metadata(
+                {"title": "Valid", "summary": "ok", "categories": []}
+            )
+
+        assert exc_info.value.errors[0]["code"] == "invalid-categories"
+
+    def test_metadata_categories_too_many(self):
+        with pytest.raises(ValidationError) as exc_info:
+            validate_solution_metadata(
+                {"categories": ["ai-ml", "storage", "cloud"]}
+            )
+
+        assert exc_info.value.errors[0]["code"] == "invalid-categories"
+
+    def test_metadata_valid_categories(self):
+        validate_solution_metadata(
+            {
+                "title": "Valid",
+                "summary": "ok",
+                "categories": ["ai-ml", "storage"],
+            }
+        )
+
+    def test_validate_solution_categories_count(self):
+        assert validate_solution_categories(["ai-ml"]) is True
+        assert validate_solution_categories(["ai-ml", "storage"]) is True
+        assert validate_solution_categories([]) is False
+        assert validate_solution_categories(["a", "b", "c"]) is False
+        assert validate_solution_categories(None) is False
+
     @patch("app.publisher.logic.get_solution_by_name")
     def test_already_exists_validation(self, mock_get_solution):
         mock_get_solution.return_value = {"name": "existing-solution"}
@@ -235,6 +268,29 @@ class TestUpdateSolutionMetadata:
             submit_for_review=True,
         )
         mock_update_published_solution.assert_not_called()
+
+    @patch("app.publisher.logic.update_draft_solution")
+    @patch("app.publisher.logic.db.session")
+    def test_submit_keeps_existing_categories_when_omitted(
+        self,
+        mock_session,
+        mock_update_draft_solution,
+    ):
+        solution = Mock(
+            status=SolutionStatus.DRAFT,
+            revision=1,
+            categories=["ai-ml"],
+        )
+        mock_session.query().filter().first.return_value = solution
+        mock_update_draft_solution.return_value = {"revision": 1}
+        metadata = {"title": "Valid", "summary": "ok"}
+
+        result = update_solution_metadata(
+            "test-solution", 1, metadata, submit_for_review=True
+        )
+
+        assert result == {"revision": 1}
+        assert metadata["categories"] == ["ai-ml"]
 
 
 class TestTransactionSafety:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,6 +29,7 @@ def test_public_serializer_excludes_private_fields():
         platform_version=[],
         platform_prerequisites=[],
         juju_versions=[],
+        categories=[],
         documentation_main=None,
         documentation_source=None,
         get_started_url=None,


### PR DESCRIPTION
## Done
- Adds backend logic to add categories to solutions
- Updates solution model to include categories
- Adds categories section to the review page of a solution

## How to QA
- Follow the steps in [this charmhub PR](https://github.com/canonical/charmhub.io/pull/2377)
- Run this service locally with `docker compose up --build`

## Testing
- [x] This PR has tests

## Issue / Card
Fixes [WD-37111](https://warthogs.atlassian.net/browse/WD-37111)

[WD-37111]: https://warthogs.atlassian.net/browse/WD-37111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ